### PR TITLE
feat: add clipboard-write permission to iframe widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@glair/web-components",
   "license": "MIT",
-  "version": "0.0.1-beta.11",
+  "version": "0.0.1-beta.12",
   "description": "A collection of GLAIR's web components",
   "keywords": [
     "glair",

--- a/src/components/gl-chat-widget.ts
+++ b/src/components/gl-chat-widget.ts
@@ -395,6 +395,7 @@ export class GLChatWidget extends LitElement {
               title="Chat Widget"
               frameborder="0"
               allowtransparency="true"
+              allow="clipboard-write"
             >
             </iframe>
           </div>


### PR DESCRIPTION
## Overview

This pull request adds explicit permission control to `iframe` according to [this article](https://web.dev/articles/async-clipboard#permissions-policy-integration) as GLChat uses Clipboard API for copy feature.