### PR TITLE
[Enhancement]: Add NPM Publish Github Workflow

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,37 @@
+# Workflow name
+name: "NPM Publish"
+
+# Event for the workflow
+on:
+  release:
+    types: [published]
+
+# List of jobs
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: endsWith(github.event.release.tag_name, '-npm') || endsWith(github.event.release.tag_name, '-npm-dry-run')
+    steps:
+      - name: Checkout to repository
+        uses: actions/checkout@v4
+      - name: Setup nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
+        run: rm package-lock.json && npm install
+        working-directory: .
+      - name: Build the app
+        run: npm run build
+        working-directory: .
+      - name: Publish to npm
+        run: |
+          if [[ ${{ github.event.release.tag_name }} == *-npm-dry-run ]]; then
+            npm publish --dry-run
+          elif [[ ${{ github.event.release.tag_name }} == *-npm ]]; then
+            npm publish
+          fi
+        working-directory: .
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Here are the steps to release the package:

1. Ensure that the tag name for the release ends with either `-npm` or `-npm-dry-run`. This is checked in the `if` condition of the `release` job.

2. Create a new release on GitHub with the desired tag name. The release should be published.

3. The workflow will automatically trigger when a new release is published.

4. The workflow will check out the repository, set up Node.js environment, install dependencies, build the app, and then publish the package to npm.

5. If the tag name ends with `-npm-dry-run`, the package will be published with the `--dry-run` flag, which means it will simulate the publish process without actually publishing the package.

6. If the tag name ends with `-npm`, the package will be published without the `--dry-run` flag, which means it will actually publish the package.

7. The `NODE_AUTH_TOKEN` environment variable is used to authenticate the npm publish process. This token should be stored as a secret in your GitHub repository settings under "Settings" -> "Secrets" with `NPM_TOKEN` secret name.

Here's an example of how to trigger the release workflow:

1. Create a new release on GitHub with the tag name ending with `-npm` or `-npm-dry-run`.
2. Push the release to GitHub.

The workflow will automatically trigger and publish the package to npm.