### PR TITLE
feat: Add custom icon slot support for gl-chat-widget and gl-chat-sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@glair/web-components",
   "license": "MIT",
-  "version": "0.0.1-beta.21",
+  "version": "0.0.1-beta.22",
   "description": "A collection of GLAIR's web components",
   "keywords": [
     "glair",

--- a/src/components/gl-chat-sidebar.ts
+++ b/src/components/gl-chat-sidebar.ts
@@ -333,7 +333,7 @@ export class GLChatSidebar extends LitElement {
           ? this.position === "left"
             ? this.toggleButtonExpandedRightIcon
             : this.toggleButtonExpandedLeftIcon
-          : this.toggleButtonMinimizedIcon}
+          : html`<slot name="icon">${this.toggleButtonMinimizedIcon}</slot>`}
       </button>
     `;
   }

--- a/src/components/gl-chat-widget.ts
+++ b/src/components/gl-chat-widget.ts
@@ -675,7 +675,7 @@ export class GLChatWidget extends LitElement {
         >
           ${this.widgetMode !== "hidden"
             ? toggleButtonExpandedIcon
-            : this.toggleButtonMinimizedIcon}
+            : html`<slot name="icon">${this.toggleButtonMinimizedIcon}</slot>`}
         </button>
       </div>
     `;


### PR DESCRIPTION
Add support for customizable icons in the minimized state of `gl-chat-widget` and `gl-chat-sidebar` components through a new 'icon' slot. This allows developers to replace the default minimized icon with custom SVG or image elements.

## Summary

- Added icon slot support to `gl-chat-widget` component
- Added icon slot support to `gl-chat-sidebar` component  
- Icon slot displays when widget/sidebar is in minimized state
- Falls back to default icon if no custom icon is provided

## How to Test

### Example 1: Using SVG Icon

```html
<gl-chat-widget url="" position="left">
  <div slot="icon">
    <svg
      width="24"
      height="24"
      viewBox="0 0 24 24"
      fill="white"
      xmlns="http://www.w3.org/2000/svg"
    >
      <path
        d="M20 24L12 16L20 8"
        stroke="#00709F"
        stroke-width="2"
        stroke-linecap="round"
        stroke-linejoin="round"
      />
    </svg>
  </div>
</gl-chat-widget>
```

Note: The width and height attributes can be customized (e.g., width="32" height="32").

### Example 2: Using Image Icon

```html
<gl-chat-widget url="" position="left">
  <div slot="icon">
    <img
      src="https://cdn.prod.website-files.com/604c4b5b0c813200c839212b/615417080a38287b82a4d866_favicon-glair.png"
      alt="GLAIR"
      width="24"
      height="24"
    />
  </div>
</gl-chat-widget>
```

Note: The width and height attributes can be customized on the img tag (e.g., width="32" height="32").

### Testing Steps

1. Use either example above in your HTML
2. Verify the custom icon appears when the widget/sidebar is minimized
3. Verify the default icon appears when no custom icon slot is provided
4. Test with different width/height values to ensure proper sizing
5. Test with both gl-chat-widget and gl-chat-sidebar components