### PR TITLE
[Enhancement]: Add `directExpandEnabled` Props

### DIFF
--- a/src/components/gl-chat-widget.ts
+++ b/src/components/gl-chat-widget.ts
@@ -14,6 +14,9 @@ export class GLChatWidget extends LitElement {
   @property({ type: String })
   colorTheme: string = "#00709F";
 
+  @property({ type: Boolean })
+  directExpandEnabled: boolean = false;
+
   // Internal state
   @state()
   private widgetMode: "hidden" | "widget" | "fullScreen" = "hidden";
@@ -549,7 +552,13 @@ export class GLChatWidget extends LitElement {
 
   private toggleWidget(): void {
     if (this.widgetMode === "hidden") {
-      this.showWidget();
+      console.log('kakaka '+ this.directExpandEnabled)
+      if (this.directExpandEnabled) {
+        console.log('kakakaka')
+        this.enterFullscreen();
+      } else {
+        this.showWidget();
+      }
     } else {
       this.hideWidget();
     }

--- a/src/components/gl-chat-widget.ts
+++ b/src/components/gl-chat-widget.ts
@@ -552,9 +552,7 @@ export class GLChatWidget extends LitElement {
 
   private toggleWidget(): void {
     if (this.widgetMode === "hidden") {
-      console.log('kakaka '+ this.directExpandEnabled)
       if (this.directExpandEnabled) {
-        console.log('kakakaka')
         this.enterFullscreen();
       } else {
         this.showWidget();


### PR DESCRIPTION
**Changes Summary**

Adds a `directExpandEnabled` boolean property to `gl-chat-widget.ts` that controls toggle behavior:

- **New property** `directExpandEnabled: boolean = false` (line 17-18)
- **Modified `toggleWidget()`**: When `directExpandEnabled` is `true`, clicking the hidden widget enters fullscreen directly instead of showing the widget first (lines 555-559)
- Contains debug `console.log` statements that should be removed

**How to Test**

1. **Default behavior** (directExpandEnabled not set or `false`):
   ```html
   <gl-chat-widget></gl-chat-widget>
   ```
   - Click once → widget expands to widget mode
   - Click again → hides or goes fullscreen (based on existing logic)

2. **Direct expand enabled**:
   ```html
   <gl-chat-widget direct-expand-enabled></gl-chat-widget>
   ```
   - Click once → goes directly to fullscreen mode

3. **Programmatic control**:
   ```javascript
   const widget = document.querySelector('gl-chat-widget');
   widget.directExpandEnabled = true;
   ```

Verify the widget responds correctly to the property toggle and check console for any unexpected debug logs that need cleanup.